### PR TITLE
Added optional no_std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ lazy_static = "1.4.0"
 [build-dependencies]
 cc = "1.0"
 rustc_version = "0.2"
+
+[features]
+default = []
+no_std = []

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,4 +1,4 @@
-use std::ffi::c_void;
+use core::ffi::c_void;
 
 pub type CallbackRaw = unsafe extern "C" fn (ptr: *mut c_void, data: *mut c_void)->();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@
 
 #![cfg_attr(all(feature = "no_std", not(test)), no_std)]
 
-#[cfg(all(nightly, not(feature = "no_std"), not(test)))] extern crate test;
+#[cfg(all(nightly, test))] extern crate test;
 
 #[allow(unused)]
 use core::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@
 //! MIT licensed
 
 
-#![cfg_attr(all(nightly, not(feature = "no_std")), feature(test))] 
+#![cfg_attr(all(nightly, test), feature(test))] 
 
 #![allow(dead_code)]
 


### PR DESCRIPTION
The AVec module is disabled when no_std feature is enabled.
all tests passed on nightly and stable with and without no_std enabled